### PR TITLE
eventsテーブルにend_timeとdescriptionカラムを追加、予定の複製機能を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,6 +38,10 @@
   }
 }
 
+.line-height-unset {
+  line-height: unset !important;
+}
+
 .w-95-per {
   width: 95% !important;
 }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -14,8 +14,13 @@ class EventsController < ApplicationController
     if @event.save
       redirect_to events_path, notice: '予定を保存しました。'
     else
-      @events = current_user.events.all
-      render :index
+      respond_to do |format|
+        format.html do
+          @events = current_user.events.all
+          render :index
+        end
+        format.js { render 'error' }
+      end
     end
   end
 
@@ -43,6 +48,12 @@ class EventsController < ApplicationController
       @event.destroy
       redirect_to events_url, notice: '予定を削除しました。'
     end
+  end
+
+  def duplicate
+    @original_event = Event.find(params[:id])
+    redirect_to root_path, status: 401, alert: '権限がありません。' if current_user.id != @original_event.user_id
+    @event = Event.new
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -47,6 +47,6 @@ class EventsController < ApplicationController
 
   private
     def event_params
-      params.require(:event).permit(:name, :start_time)
+      params.require(:event).permit(:name, :description, :start_time, :end_time)
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,20 @@ module ApplicationHelper
       "#{l start_time, format: :long}~#{l end_time, format: :long}"
     end
   end
+
+  def form_modal_title
+    if controller.action_name == 'edit'
+      '予定を編集'
+    else
+      '予定を複製'
+    end
+  end
+
+  def submit_button_text
+    if controller.action_name == 'edit'
+      '更新'
+    else
+      '保存'
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper
+  def start_time_or_end_time(day, start_time, end_time)
+    if day == start_time.day
+      "#{l start_time}~"
+    elsif day == end_time.day
+      "~#{l end_time}"
+    else
+      '終日'
+    end
+  end
+
+  def show_time(start_time, end_time)
+    if start_time.day == end_time.day
+      "#{l start_time, format: :long}~#{l end_time}"
+    else
+      "#{l start_time, format: :long}~#{l end_time, format: :long}"
+    end
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,4 +3,16 @@ class Event < ApplicationRecord
 
   validates :name, presence: true
   validates :start_time, presence: true
+  validates :end_time, presence: true
+  validate :time_validation
+
+  def time_validation
+    if start_time.blank?
+      errors.add(:start_time, 'を入力してください')
+    elsif end_time.blank?
+      errors.add(:end_time, 'を入力してください')
+    elsif start_time > end_time
+      errors.add(:end_time, 'は開始時刻以降の時間を入力してください')
+    end
+  end
 end

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -6,7 +6,12 @@
       <button class="delete" id="close-events-show-<%= event.id %>-modal" aria-label="close"></button>
     </header>
     <section class="modal-card-body">
-      <%= l event.start_time, format: :long %>
+      <div class="content text-break">
+        <p>
+          <%= show_time(event.start_time, event.end_time) %>
+        </p>
+        <p><%= event.description %></p>
+      </div>
     </section>
     <footer class="modal-card-foot is-flex is-justify-content-end">
       <%= link_to '編集', edit_event_path(event), remote: true, class: 'button is-rounded is-info' %>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-background"></div>
   <div class="modal-card">
     <header class="modal-card-head">
-      <p class="modal-card-title text-break is-1-line w-95-per" title="<%= event.name %>"><span><%= event.name %></span></p>
+      <p class="modal-card-title text-break is-1-line w-95-per line-height-unset" title="<%= event.name %>"><span><%= event.name %></span></p>
       <button class="delete" id="close-events-show-<%= event.id %>-modal" aria-label="close"></button>
     </header>
     <section class="modal-card-body">

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -16,6 +16,7 @@
     <footer class="modal-card-foot is-flex is-justify-content-end">
       <%= link_to '編集', edit_event_path(event), remote: true, class: 'button is-rounded is-info' %>
       <%= link_to '削除', event_path(event), method: :delete, data: { confirm: '本当に予定を削除しますか？一度削除すると、復元することはできません。' }, class: 'button is-rounded rspec_destroy_event' %>
+      <%= link_to '複製', duplicate_event_path(event), remote: true, class: 'button is-rounded' %>
     </footer>
   </div>
 </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -11,7 +11,7 @@
           <div class="field">
             <%= f.label :name, class: 'label' %>
             <div class="control">
-              <%= f.text_field  :name, required: true, class: 'input' %>
+              <%= f.text_field :name, required: true, class: 'input' %>
             </div>
           </div>
 
@@ -19,6 +19,20 @@
             <%= f.label :start_time, class: 'label' %>
             <div class="control">
               <%= f.datetime_field :start_time, required: true, class: 'input' %>
+            </div>
+          </div>
+
+          <div class="field">
+            <%= f.label :end_time, class: 'label' %>
+            <div class="control">
+              <%= f.datetime_field :end_time, required: true, class: 'input' %>
+            </div>
+          </div>
+
+          <div class="field">
+            <%= f.label :description, class: 'label' %>
+            <div class="control">
+              <%= f.text_area :description, required: true, class: 'textarea' %>
             </div>
           </div>
           <% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -25,7 +25,7 @@
         </div>
       </section>
       <footer class="modal-card-foot is-flex is-justify-content-end">
-        <button class="button is-rounded is-info" type="submit" form="events-form">更新</button>
+        <button class="button is-rounded is-info" id="update-button" type="submit" form="events-form">更新</button>
       </footer>
   </div>
 </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-background"></div>
   <div class="modal-card">
     <header class="modal-card-head">
-      <p class="modal-card-title is-4">予定を編集</p>
+      <p class="modal-card-title is-4"><%= form_modal_title %></p>
       <button class="delete" id="close-events-form-modal" aria-label="close"></button>
     </header>
       <section class="modal-card-body">
@@ -39,7 +39,7 @@
         </div>
       </section>
       <footer class="modal-card-foot is-flex is-justify-content-end">
-        <button class="button is-rounded is-info" id="update-button" type="submit" form="events-form">更新</button>
+        <button class="button is-rounded is-info" id="update-button" type="submit" form="events-form"><%= submit_button_text %></button>
       </footer>
   </div>
 </div>

--- a/app/views/events/duplicate.js.erb
+++ b/app/views/events/duplicate.js.erb
@@ -1,0 +1,41 @@
+var eventsShowModal = document.getElementById('events-show-<%= @original_event.id %>-modal')
+var body = document.querySelector('body');
+var html = document.querySelector('html');
+
+if (eventsShowModal) {
+  eventsShowModal.classList.remove('is-active');
+  html.classList.remove('is-clipped');
+  body.classList.remove('mr-4');
+}
+
+var eventsFormModal = document.getElementById('events-form-modal')
+if (eventsFormModal) {
+  eventsFormModal.remove();
+}
+
+body.insertAdjacentHTML('beforeend', '<%= j(render "form", event: @event) %>');
+
+var eventsFormModal = document.getElementById('events-form-modal')
+
+eventsFormModal.querySelector('#event_name').value = "<%= @original_event.name %>";
+eventsFormModal.querySelector('#event_start_time').value = "<%= l(@original_event.start_time, format: :input_value) %>";
+eventsFormModal.querySelector('#event_end_time').value = "<%= l(@original_event.end_time, format: :input_value) %>";
+eventsFormModal.querySelector('#event_description').value = "<%= @original_event.description %>";
+
+eventsFormModal.classList.add('is-active');
+html.classList.add('is-clipped');
+body.classList.add('mr-4');
+
+var eventsFormModalCloseButton = eventsFormModal.querySelector('#close-events-form-modal');
+eventsFormModalCloseButton.addEventListener('click', () => {
+  eventsFormModal.classList.remove('is-active');
+  html.classList.remove('is-clipped');
+  body.classList.remove('mr-4');
+});
+
+var eventsFormModalBg = eventsFormModal.querySelector('.modal-background');
+eventsFormModalBg.addEventListener('click', () => {
+  eventsFormModal.classList.remove('is-active');
+  html.classList.remove('is-clipped');
+  body.classList.remove('mr-4');
+});

--- a/app/views/events/edit.js.erb
+++ b/app/views/events/edit.js.erb
@@ -34,3 +34,10 @@ eventsFormModalBg.addEventListener('click', () => {
   html.classList.remove('is-clipped');
   body.classList.remove('mr-4');
 });
+
+var eventsFormUpdateButton = document.getElementById('update-button')
+eventsFormUpdateButton.addEventListener('click', () => {
+  eventsFormModal.classList.remove('is-active');
+  html.classList.remove('is-clipped');
+  body.classList.remove('mr-4');
+});

--- a/app/views/events/error.js.erb
+++ b/app/views/events/error.js.erb
@@ -2,3 +2,10 @@ var eventsFormModal = document.getElementById('events-form-modal')
 var modalCardBody = eventsFormModal.querySelector('.modal-card-body')
 
 modalCardBody.insertAdjacentHTML('afterbegin', '<%= j(render "shared/error_messages", model: @event) %>');
+
+var body = document.querySelector('body');
+var html = document.querySelector('html');
+
+eventsFormModal.classList.add('is-active');
+html.classList.add('is-clipped');
+body.classList.add('mr-4');

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,5 +1,5 @@
 <section class="section">
-  <%= month_calendar(events: @events) do |date, events| %>
+  <%= month_calendar(events: @events, attribute: :start_time, end_attribute: :end_time) do |date, events| %>
     <p class="has-text-centered">
       <%= date.day %>
     </p>
@@ -8,7 +8,7 @@
       <% events.each do |event| %>
         <%= link_to event_path(event), remote: true do %>
           <li class="text-break is-1-line has-text-black hover-has-background-light mb-1" title="<%= event.name %>">
-            <span><%= l event.start_time %> <%= event.name %></span>
+            <span><%= start_time_or_end_time(date.day, event.start_time, event.end_time) %> <%= event.name %></span>
           </li>
         <% end %>
       <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -31,7 +31,7 @@
           <div class="field">
             <%= f.label :name, class: 'label' %>
             <div class="control">
-              <%= f.text_field  :name, required: true, class: 'input' %>
+              <%= f.text_field :name, required: true, class: 'input' %>
             </div>
           </div>
 
@@ -39,6 +39,20 @@
             <%= f.label :start_time, class: 'label' %>
             <div class="control">
               <%= f.datetime_field :start_time, required: true, class: 'input' %>
+            </div>
+          </div>
+
+          <div class="field">
+            <%= f.label :end_time, class: 'label' %>
+            <div class="control">
+              <%= f.datetime_field :end_time, required: true, class: 'input' %>
+            </div>
+          </div>
+
+          <div class="field">
+            <%= f.label :description, class: 'label' %>
+            <div class="control">
+              <%= f.text_area :description, required: true, class: 'textarea' %>
             </div>
           </div>
           <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -5,7 +5,7 @@
       <%= "エラーが発生したため入力された内容は保存されませんでした。" %>
     </p>
     <ul>
-      <% model.errors.full_messages.each do |message| %>
+      <% model.errors.full_messages.uniq.each do |message| %>
         <li><%= message %></li>
       <% end %>
     </ul>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,7 +7,7 @@ ja:
         name: 名前
         description: 説明
         start_time: 開始時刻
-        end_time: 開始時刻
+        end_time: 終了時刻
   time:
     formats:
       default: "%-H:%M"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,7 +5,9 @@ ja:
     attributes:
       event:
         name: 名前
+        description: 説明
         start_time: 開始時刻
+        end_time: 開始時刻
   time:
     formats:
       default: "%-H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Rails.application.routes.draw do
   end
   get 'users', to: 'home#index'
 
-  resources :events, only: %i(index show create edit update destroy)
+  resources :events, only: %i(index show create edit update destroy) do
+    member do
+      get 'duplicate'
+    end
+  end
 
   root to: 'home#index'
 end

--- a/db/migrate/20210917055702_add_description_and_end_time_to_events.rb
+++ b/db/migrate/20210917055702_add_description_and_end_time_to_events.rb
@@ -1,0 +1,6 @@
+class AddDescriptionAndEndTimeToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :description, :text
+    add_column :events, :end_time, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_15_101448) do
+ActiveRecord::Schema.define(version: 2021_09_17_055702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2021_09_15_101448) do
     t.datetime "start_time", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "description"
+    t.datetime "end_time", null: false
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,3 +42,11 @@ guest_user.events.create!(
   start_time: randomized_time,
   end_time: randomized_time + 2.days,
 )
+
+randomized_time = Random.rand(start_day..last_day) + rand(24).hour + rand(60).minutes
+guest_user.events.create!(
+  name: 'a'*255,
+  description: 'a'*2000,
+  start_time: randomized_time,
+  end_time: randomized_time + rand(24).hours,
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,44 @@
+Faker::Config.locale = :en
+
 guest_user = User.guest
 
-start_day = DateTime.new(2021, 8, 1)
-last_day = DateTime.new(2021, 10, 31)
+lorem_description = Faker::Lorem.paragraphs(number: 5).join(' ')
+start_day = DateTime.new(2021, 9, 1)
+last_day = start_day + rand(30).days
 
-50.times do
+5.times do
+  randomized_time = Random.rand(start_day..last_day) + rand(24).hour + rand(60).minutes
   guest_user.events.create!(
     name: Faker::Hobby.activity,
-    start_time: Random.rand(start_day..last_day),
+    description: lorem_description,
+    start_time: randomized_time,
+    end_time: randomized_time + rand(24).hours,
   )
 end
+
+randomized_time = Random.rand(start_day..last_day) + rand(24).hour + rand(60).minutes
+
+guest_user.events.create!(
+  name: Faker::Hobby.activity,
+  description: lorem_description,
+  start_time: randomized_time,
+  end_time: randomized_time,
+)
+
+randomized_time = Random.rand(start_day..last_day) + rand(24).hour + rand(60).minutes
+
+guest_user.events.create!(
+  name: Faker::Hobby.activity,
+  description: lorem_description,
+  start_time: randomized_time,
+  end_time: randomized_time + 1.days,
+)
+
+randomized_time = Random.rand(start_day..last_day) + rand(24).hour + rand(60).minutes
+
+guest_user.events.create!(
+  name: Faker::Hobby.activity,
+  description: lorem_description,
+  start_time: randomized_time,
+  end_time: randomized_time + 2.days,
+)

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,9 +1,15 @@
 FactoryBot.define do
   factory :event do
-    name { Faker::Hobby.activity }
+    lorem_description = Faker::Lorem.paragraphs(number: 5).join(' ')
     start_day = DateTime.now - 15.days
     last_day = DateTime.now + 15.days
-    start_time { Random.rand(start_day..last_day) }
+    randomized_time = Random.rand(start_day..last_day)
+
+    name { Faker::Hobby.activity }
+    description { lorem_description }
+    start_time { randomized_time }
+    end_time { randomized_time + 5.hours }
+
     association :user
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -4,5 +4,47 @@ RSpec.describe Event, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:start_time) }
+    it { is_expected.to validate_presence_of(:end_time) }
+
+    describe 'time_validation' do
+      context 'start_time > end_time' do
+        it 'is invalid' do
+          set_start_time = DateTime.new(2021, 1, 1, 12)
+          set_end_time = set_start_time - 1.hour
+
+          event = build_stubbed(:event, start_time: set_start_time, end_time: set_end_time)
+          expect(event.valid?).to eq false
+        end
+
+        it 'has error message' do
+          set_start_time = DateTime.new(2021, 1, 1, 12)
+          set_end_time = set_start_time - 1.hour
+
+          event = build_stubbed(:event, start_time: set_start_time, end_time: set_end_time)
+          event.valid?
+          expect(event.errors[:end_time]).to include 'は開始時刻以降の時間を入力してください'
+        end
+      end
+
+      context 'start_time == end_time' do
+        it 'is valid' do
+          set_start_time = DateTime.new(2021, 1, 1, 12)
+          set_end_time = set_start_time
+
+          event = build_stubbed(:event, start_time: set_start_time, end_time: set_end_time)
+          expect(event.valid?).to eq true
+        end
+      end
+
+      context 'start_time < end_time' do
+        it 'is valid' do
+          set_start_time = DateTime.new(2021, 1, 1, 12)
+          set_end_time = set_start_time + 1.hour
+
+          event = build_stubbed(:event, start_time: set_start_time, end_time: set_end_time)
+          expect(event.valid?).to eq true
+        end
+      end
+    end
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Events', type: :request do
 
     context 'signed in' do
       let(:alice) { create :user }
-      let!(:event) { create :event, start_time: DateTime.now, user: alice }
+      let!(:event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
 
       it 'returns a 200 response' do
         sign_in alice
@@ -103,7 +103,7 @@ RSpec.describe 'Events', type: :request do
   describe 'GET /events/:id' do
     let(:alice) { create :user }
     let(:bob) { create :user }
-    let!(:event) { create :event, start_time: DateTime.now, user: alice }
+    let!(:event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
 
     context 'not signed in' do
       it 'returns a 401 response' do
@@ -160,7 +160,7 @@ RSpec.describe 'Events', type: :request do
   describe 'GET /events/:id/edit' do
     let(:alice) { create :user }
     let(:bob) { create :user }
-    let!(:event) { create :event, start_time: DateTime.now, user: alice }
+    let!(:event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
 
     context 'not signed in' do
       it 'returns a 401 response' do
@@ -228,7 +228,7 @@ RSpec.describe 'Events', type: :request do
   describe 'PUT /events/:id' do
     let(:alice) { create :user }
     let(:bob) { create :user }
-    let!(:event) { create :event, start_time: DateTime.now, user: alice }
+    let!(:event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
 
     context 'not signed in' do
       it 'returns a 401 response' do
@@ -340,7 +340,7 @@ RSpec.describe 'Events', type: :request do
   describe 'DELETE /events/:id' do
     let(:alice) { create :user }
     let(:bob) { create :user }
-    let!(:event) { create :event, start_time: DateTime.now, user: alice }
+    let!(:event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
 
     context 'not signed in' do
       it 'returns a 302 response' do

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe 'Events', type: :system do
       click_button '作成'
       fill_in 'event[name]', with: event.name
       fill_in 'event[start_time]', with: event.start_time
+      fill_in 'event[end_time]', with: event.end_time
+      fill_in 'event[description]', with: event.description
       expect{
         click_button '保存'
       }.to change { Event.count }.by(1)

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -83,4 +83,26 @@ RSpec.describe 'Events', type: :system do
       expect(alice.events.count).to eq 0
     end
   end
+
+  describe 'duplicate event' do
+    let(:alice) { create :user }
+    let!(:original_event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
+
+    it 'duplicates event', js: true do
+      original_event_name = original_event.name
+      expect(alice.events.count).to eq 1
+      sign_in alice
+      visit events_path
+      click_link href: event_path(original_event)
+      click_link href: duplicate_event_path(original_event)
+      expect(page).to have_content original_event_name
+      fill_in 'event[name]', with: 'not original event name'
+      fill_in 'event[start_time]', with: DateTime.now
+      fill_in 'event[end_time]', with: DateTime.now + 1.hour
+      click_button '保存'
+      expect(page).to have_content '予定を保存しました。'
+      expect(alice.events.count).to eq 2
+      expect(original_event.reload.name).to eq original_event_name
+    end
+  end
 end

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Events', type: :system do
   describe 'show events' do
     let(:alice) { create :user }
-    let!(:event) { create :event, start_time: DateTime.now, user: alice }
+    let!(:event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
 
     it 'shows events' do
       sign_in alice
@@ -15,14 +15,15 @@ RSpec.describe 'Events', type: :system do
 
   describe 'show event' do
     let(:alice) { create :user }
-    let!(:event) { create :event, start_time: DateTime.now, user: alice }
+    let!(:event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
 
     it 'shows the event', js: true do
       sign_in alice
       visit events_path
       click_link href: event_path(event)
       expect(page).to have_content event.name
-      expect(page).to have_content I18n.l(event.start_time, format: :long)
+      expect(page).to have_content "#{I18n.l(event.start_time, format: :long)}~#{I18n.l(event.end_time)}"
+      expect(page).to have_content event.description
     end
   end
 

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Events', type: :system do
 
   describe 'create event' do
     let(:alice) { create :user }
-    let(:event) { build_stubbed :event, start_time: DateTime.now }
+    let(:event) { build_stubbed :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour }
 
     it 'creates event', js: true do
       sign_in alice
@@ -49,7 +49,7 @@ RSpec.describe 'Events', type: :system do
 
   describe 'update event' do
     let(:alice) { create :user }
-    let!(:event) { create :event, start_time: DateTime.now, user: alice }
+    let!(:event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
 
     it 'creates event', js: true do
       old_event_name = event.name
@@ -67,7 +67,7 @@ RSpec.describe 'Events', type: :system do
 
   describe 'destroy event' do
     let(:alice) { create :user }
-    let!(:event) { create :event, start_time: DateTime.now, user: alice }
+    let!(:event) { create :event, start_time: DateTime.now, end_time: DateTime.now + 1.hour, user: alice }
 
     it 'creates event', js: true do
       expect(alice.events.count).to eq 1


### PR DESCRIPTION
- 予定を更新後に画面がスクロールできなくなるバグを修正
- ​eventsテーブルにend_timeとdescriptionカラムを追加
- 予定の複製機能を追加